### PR TITLE
Support for importing members

### DIFF
--- a/docs/Model/MemberInfoModel.md
+++ b/docs/Model/MemberInfoModel.md
@@ -1,0 +1,36 @@
+<!-- generated file with tool "Kentico.Xperience.UMT.DocUtils" - edited through template "UmtModel.cshtml" -->
+## MemberInfoModel
+Model represents XbyK MemberInfo
+
+Model [discriminator](../UmtModel.md#discriminator): `MemberInfo`
+
+|PropertyName|Summary|.NET Type|Notes|
+|---|---|---|---|
+|MemberName\*|member name / login name - must be unique|string?||
+|MemberEmail\*|valid email address according to XbyK API domain requirements (ValidationHelper.IsEmail()) or custom regex set through configuration "CMSEmailValidationRegex"|string?||
+|MemberPassword|hashed member password|string?||
+|MemberEnabled\*|disable/enable member|bool?||
+|MemberCreated|datetime of member creation, defaults to current server time|System.DateTime?||
+|MemberGUID\*|uniqueId of member used for reference in other models|System.Guid?|[UniqueId](../UmtModel.md#UniqueId)|
+|MemberIsExternal\*||bool?||
+|MemberSecurityStamp||string?||
+|[customPropertyName]|custom property defined by created [DataClass](./DataClassModel.md)|.NET type defined by data class field||
+
+<p>*) value is required</p>
+
+
+### Instance of dataclass MemberInfo - Sample member without custom fields
+Sample demonstrates how to create a member without custom fields
+```json
+{
+  "$type": "MemberInfo",
+  "MemberName": "John Doe",
+  "MemberEmail": "john.doe@sample.localhost",
+  "MemberPassword": "[sample hash]",
+  "MemberEnabled": true,
+  "MemberCreated": "2003-02-01T04:05:06.007Z",
+  "MemberGUID": "4834f3c4-f7a5-46b8-a83d-607fcfc555d7",
+  "MemberIsExternal": false,
+  "MemberSecurityStamp": "[sample security stamp]"
+}
+```

--- a/docs/Model/UMT.schema.json
+++ b/docs/Model/UMT.schema.json
@@ -989,7 +989,7 @@
           "properties": {
             "UserName": {
               "type": "string",
-              "description": "user nane / login name - must be unique",
+              "description": "user name / login name - must be unique",
               "minLength": 1
             },
             "FirstName": {
@@ -1079,6 +1079,78 @@
             },
             "UserIsExternal": {
               "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "MemberInfoModel": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/UmtModel"
+        },
+        {
+          "type": "object",
+          "description": "Model represents XbyK MemberInfo",
+          "additionalProperties": {
+            "oneOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "required": [
+            "MemberName",
+            "MemberEmail",
+            "MemberEnabled",
+            "MemberGUID",
+            "MemberIsExternal"
+          ],
+          "properties": {
+            "MemberName": {
+              "type": "string",
+              "description": "member name / login name - must be unique",
+              "minLength": 1
+            },
+            "MemberEmail": {
+              "type": "string",
+              "description": "valid email address according to XbyK API domain requirements (ValidationHelper.IsEmail()) or custom regex set through configuration \"CMSEmailValidationRegex\"",
+              "minLength": 1
+            },
+            "MemberPassword": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "hashed member password"
+            },
+            "MemberEnabled": {
+              "type": "boolean",
+              "description": "disable/enable member"
+            },
+            "MemberCreated": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "datetime of member creation, defaults to current server time ",
+              "format": "date-time"
+            },
+            "MemberGUID": {
+              "type": "string",
+              "description": "uniqueId of member used for reference in other models ",
+              "format": "guid",
+              "minLength": 1
+            },
+            "MemberIsExternal": {
+              "type": "boolean"
+            },
+            "MemberSecurityStamp": {
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         }

--- a/docs/Model/UserInfoModel.md
+++ b/docs/Model/UserInfoModel.md
@@ -6,7 +6,7 @@ Model [discriminator](../UmtModel.md#discriminator): `UserInfo`
 
 |PropertyName|Summary|.NET Type|Notes|
 |---|---|---|---|
-|UserName\*|user nane / login name - must be unique|string?||
+|UserName\*|user name / login name - must be unique|string?||
 |FirstName|First name of user|string?||
 |LastName|Last name of user|string?||
 |Email\*|valid email address according to XbyK API domain requirements (ValidationHelper.IsEmail()) or custom regex set through configuration "CMSEmailValidationRegex"|string?||

--- a/docs/Samples/basic.json
+++ b/docs/Samples/basic.json
@@ -114,6 +114,17 @@
     "UserIsExternal": false
   },
   {
+    "$type": "MemberInfo",
+    "MemberName": "John Doe",
+    "MemberEmail": "john.doe@sample.localhost",
+    "MemberPassword": "[sample hash]",
+    "MemberEnabled": true,
+    "MemberCreated": "2003-02-01T04:05:06.007Z",
+    "MemberGUID": "4834f3c4-f7a5-46b8-a83d-607fcfc555d7",
+    "MemberIsExternal": false,
+    "MemberSecurityStamp": "[sample security stamp]"
+  },
+  {
     "$type": "ContentLanguage",
     "ContentLanguageGUID": "f454e93b-5fe9-42a9-b1af-b572234ed9c4",
     "ContentLanguageDisplayName": "English (United States)",

--- a/examples/Kentico.Xperience.UMT.Example.AdminApp/Data/Samples.json
+++ b/examples/Kentico.Xperience.UMT.Example.AdminApp/Data/Samples.json
@@ -114,6 +114,17 @@
     "UserIsExternal": false
   },
   {
+    "$type": "MemberInfo",
+    "MemberName": "John Doe",
+    "MemberEmail": "john.doe@sample.localhost",
+    "MemberPassword": "[sample hash]",
+    "MemberEnabled": true,
+    "MemberCreated": "2003-02-01T04:05:06.007Z",
+    "MemberGUID": "4834f3c4-f7a5-46b8-a83d-607fcfc555d7",
+    "MemberIsExternal": false,
+    "MemberSecurityStamp": "[sample security stamp]"
+  },
+  {
     "$type": "ContentLanguage",
     "ContentLanguageGUID": "f454e93b-5fe9-42a9-b1af-b572234ed9c4",
     "ContentLanguageDisplayName": "English (United States)",

--- a/examples/Kentico.Xperience.UMT.Examples/SampleProvider.cs
+++ b/examples/Kentico.Xperience.UMT.Examples/SampleProvider.cs
@@ -52,6 +52,10 @@ public static class SampleProvider
         // sample data
         sourceData.AddRange([
             UserSamples.SampleAdministrator,
+
+            MemberSamples.SampleMemberNoCustomFields,
+            //MemberSamples.SampleMemberWithCustomFields, // Intentionally not included, because the included custom fields are not by default present in boilerplate project
+
             ContentLanguageSamples.SampleContentLanguageEnUs,
             ContentLanguageSamples.SampleContentLanguageEnGb,
             ContentLanguageSamples.SampleContentLanguageEs,

--- a/examples/Kentico.Xperience.UMT.Examples/Samples/MemberSamples.cs
+++ b/examples/Kentico.Xperience.UMT.Examples/Samples/MemberSamples.cs
@@ -1,0 +1,37 @@
+﻿using Kentico.Xperience.UMT.Model;
+
+namespace Kentico.Xperience.UMT.Examples;
+
+public static class MemberSamples
+{
+    [Sample("memberinfo.sample.nocustomfields", "Sample demonstrates how to create a member without custom fields", "Instance of dataclass MemberInfo - Sample member without custom fields")]
+    public static MemberInfoModel SampleMemberNoCustomFields => new()
+    {
+        MemberGUID = new Guid("4834F3C4-F7A5-46B8-A83D-607FCFC555D7"),
+        MemberEmail = "john.doe@sample.localhost",
+        MemberName = "John Doe",
+        MemberCreated = new DateTime(2003, 02, 01, 4, 5, 6, 7, DateTimeKind.Utc),
+        MemberEnabled = true,
+        MemberIsExternal = false,
+        MemberPassword = "[sample hash]",
+        MemberSecurityStamp = "[sample security stamp]"
+    };
+
+    [Sample("memberinfo.sample.withcustomfields", "Sample demonstrates how to create a member with custom fields. Prior to usage, add the Member custom fields (see XbyK docs)", "Instance of dataclass MemberInfo - Sample member with custom fields")]
+    public static MemberInfoModel SampleMemberWithCustomFields => new()
+    {
+        MemberGUID = new Guid("3DBA2983-33A3-46F5-B77C-EAC89FDB9559"),
+        MemberEmail = "martin.atkins@sample.local",
+        MemberName = "Martin Atkins",
+        MemberCreated = new DateTime(2004, 06, 07, 3, 0, 0, 0, DateTimeKind.Utc),
+        MemberEnabled = true,
+        MemberIsExternal = false,
+        MemberPassword = "[sample hash]",
+        MemberSecurityStamp = "[sample security stamp]",
+        CustomProperties =
+        {
+            ["MemberCity"] = "New York",
+            ["MemberScore"] = 5,
+        }
+    };
+}

--- a/src/Kentico.Xperience.UMT/InfoAdapter/AdapterFactory.cs
+++ b/src/Kentico.Xperience.UMT/InfoAdapter/AdapterFactory.cs
@@ -24,6 +24,7 @@ internal class AdapterFactory(ILoggerFactory loggerFactory, UmtModelService mode
         return umtModel switch
         {
             UserInfoModel => new UserAdapter(loggerFactory.CreateLogger<UserAdapter>(), adapterContext),
+            MemberInfoModel => new MemberAdapter(loggerFactory.CreateLogger<MemberAdapter>(), adapterContext),
             MediaFileModel => new MediaFileAdapter(loggerFactory.CreateLogger<MediaFileAdapter>(), adapterContext),
             MediaLibraryModel => new GenericInfoAdapter<MediaLibraryInfo>(loggerFactory.CreateLogger<GenericInfoAdapter<MediaLibraryInfo>>(), adapterContext),
             ContentItemLanguageMetadataModel => new GenericInfoAdapter<ContentItemLanguageMetadataInfo>(loggerFactory.CreateLogger<GenericInfoAdapter<ContentItemLanguageMetadataInfo>>(), adapterContext),

--- a/src/Kentico.Xperience.UMT/InfoAdapter/MemberAdapter.cs
+++ b/src/Kentico.Xperience.UMT/InfoAdapter/MemberAdapter.cs
@@ -8,16 +8,4 @@ internal class MemberAdapter : GenericInfoAdapter<MemberInfo>
     internal MemberAdapter(ILogger<MemberAdapter> logger, GenericInfoAdapterContext context) : base(logger, context)
     {
     }
-
-    //protected override void SetValue(UserInfo current, string propertyName, object? value)
-    //{
-    //    if (propertyName == "UserPassword")
-    //    {
-    //        current.SetValue("UserPassword", value);
-    //    }
-    //    else
-    //    {
-    //        base.SetValue(current, propertyName, value);
-    //    }
-    //}
 }

--- a/src/Kentico.Xperience.UMT/InfoAdapter/MemberAdapter.cs
+++ b/src/Kentico.Xperience.UMT/InfoAdapter/MemberAdapter.cs
@@ -1,0 +1,23 @@
+﻿using CMS.Membership;
+using Microsoft.Extensions.Logging;
+
+namespace Kentico.Xperience.UMT.InfoAdapter;
+
+internal class MemberAdapter : GenericInfoAdapter<MemberInfo>
+{
+    internal MemberAdapter(ILogger<MemberAdapter> logger, GenericInfoAdapterContext context) : base(logger, context)
+    {
+    }
+
+    //protected override void SetValue(UserInfo current, string propertyName, object? value)
+    //{
+    //    if (propertyName == "UserPassword")
+    //    {
+    //        current.SetValue("UserPassword", value);
+    //    }
+    //    else
+    //    {
+    //        base.SetValue(current, propertyName, value);
+    //    }
+    //}
+}

--- a/src/Kentico.Xperience.UMT/Model/Auxiliary/UmtModel.cs
+++ b/src/Kentico.Xperience.UMT/Model/Auxiliary/UmtModel.cs
@@ -26,6 +26,7 @@ public interface IUmtModel
 [KnownType(typeof(MediaFileModel))]
 [KnownType(typeof(MediaLibraryModel))]
 [KnownType(typeof(UserInfoModel))]
+[KnownType(typeof(MemberInfoModel))]
 [KnownType(typeof(WebPageItemModel))]
 [KnownType(typeof(WebPageAclModel))]
 [KnownType(typeof(WebPageUrlPathModel))]

--- a/src/Kentico.Xperience.UMT/Model/MemberInfoModel.cs
+++ b/src/Kentico.Xperience.UMT/Model/MemberInfoModel.cs
@@ -1,0 +1,68 @@
+﻿// ReSharper disable InconsistentNaming
+
+using System.ComponentModel.DataAnnotations;
+using Kentico.Xperience.UMT.Attributes;
+
+namespace Kentico.Xperience.UMT.Model;
+
+/// <summary>
+/// Model represents XbyK MemberInfo
+/// </summary>
+/// <sample>memberinfo.sample.nocustomfields</sample>
+[UmtModel(DISCRIMINATOR)]
+public class MemberInfoModel : UmtModel
+{
+    /// <summary>
+    /// Discriminator used in serialized structures to identify model 
+    /// </summary>
+    public const string DISCRIMINATOR = "MemberInfo";
+
+    /// <summary>
+    /// member name / login name - must be unique
+    /// </summary>
+    [Map]
+    [Required]
+    public string? MemberName { get; set; }
+
+    /// <summary>
+    /// valid email address according to XbyK API domain requirements (ValidationHelper.IsEmail()) or custom regex set through configuration "CMSEmailValidationRegex"
+    /// </summary>
+    [Map]
+    [Required]
+    public string? MemberEmail { get; set; }
+
+    /// <summary>
+    /// hashed member password
+    /// </summary>
+    [Map]
+    public string? MemberPassword { get; set; }
+
+    /// <summary>
+    /// disable/enable member
+    /// </summary>
+    [Map]
+    [Required]
+    public bool? MemberEnabled { get; set; }
+
+    /// <summary>
+    /// datetime of member creation, defaults to current server time 
+    /// </summary>
+    [Map]
+    public DateTime? MemberCreated { get; set; }
+
+    /// <summary>
+    /// uniqueId of member used for reference in other models 
+    /// </summary>
+    [UniqueIdProperty]
+    [Required]
+    public Guid? MemberGUID { get; set; }
+
+    [Map]
+    [Required]
+    public bool? MemberIsExternal { get; set; }
+
+    [Map]
+    public string? MemberSecurityStamp { get; set; }
+
+    protected override (Guid? uniqueId, string? name, string? displayName) GetPrintArgs() => (MemberGUID, MemberName, NOT_AVAILABLE);
+}

--- a/src/Kentico.Xperience.UMT/Model/UserInfoModel.cs
+++ b/src/Kentico.Xperience.UMT/Model/UserInfoModel.cs
@@ -23,7 +23,7 @@ public class UserInfoModel : UmtModel
 #pragma warning restore S125
 
     /// <summary>
-    /// user nane / login name - must be unique
+    /// user name / login name - must be unique
     /// </summary>
     [Map]
     [Required]


### PR DESCRIPTION
Add: Support for importing members

# Motivation
Implementation of feature request

## Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test
Import the full sample, e.g. by running the project Kentico.Xperience.UMT.Example.Console. The full sample contains a bare member sample without custom fields.

To test import of members with custom fields, first add the fields to Member class through admin interface Development->Modules->Membership->Classes->Member->Database columns, then import the sample MemberSamples.SampleMemberWithCustomFields - e.g. by replacing the following line in Example.Console project Program.cs

sourceData = SampleProvider.GetFullSample();

by this line

sourceData = new List<IUmtModel>([MemberSamples.SampleMemberWithCustomFields]);

and running the project.
