### PR TITLE
Fix content hub previews of items with image asset

### DIFF
--- a/src/Kentico.Xperience.UMT/Model/Auxiliary/AssetSource.cs
+++ b/src/Kentico.Xperience.UMT/Model/Auxiliary/AssetSource.cs
@@ -14,10 +14,8 @@ namespace Kentico.Xperience.UMT.Model;
 public class AssetSource
 {
     public const string DISCRIMINATOR_PROPERTY = "$assetType";
-    
     [Required]
     public Guid? ContentItemGuid { get; set; }
-    
     [Required]
     public Guid? Identifier { get; set; }
     [Required]
@@ -26,6 +24,8 @@ public class AssetSource
     public string? Extension { get; set; }
     public long? Size { get; set; }
     public DateTime? LastModified { get; set; }
+
+    public virtual string InferExtension() => Extension ?? throw new InvalidOperationException($"{nameof(AssetFileSource)} has unknown extension. Specify explicitly by {nameof(Extension)} property");
 }
 
 
@@ -33,6 +33,8 @@ public class AssetFileSource : AssetSource
 {
     [Required]
     public string? FilePath { get; set; }
+
+    public override string InferExtension() => Extension ?? CMS.IO.FileInfo.New(FilePath).Extension ?? throw new InvalidOperationException($"{nameof(AssetFileSource)} has unknown extension. Specify explicitly by {nameof(Extension)} property");
 }
 
 public class AssetUrlSource : AssetSource
@@ -44,5 +46,5 @@ public class AssetUrlSource : AssetSource
 public class AssetDataSource : AssetSource
 {
     [Required]
-    public byte[]? Data { get; set; } 
+    public byte[]? Data { get; set; }
 }

--- a/src/Kentico.Xperience.UMT/Services/AssetManager.cs
+++ b/src/Kentico.Xperience.UMT/Services/AssetManager.cs
@@ -37,7 +37,7 @@ internal class AssetManager(
 
                     var assetMetadata = new ContentItemAssetMetadata
                     {
-                        Extension = byteSource.Extension,
+                        Extension = assetSource.InferExtension(),
                         Identifier = byteSource.Identifier.Value,
                         LastModified = byteSource.LastModified ?? dateTimeNowService.GetDateTimeNow(),
                         Name = byteSource.Name,
@@ -58,7 +58,7 @@ internal class AssetManager(
                     var file = CMS.IO.FileInfo.New(fileSource.FilePath);
                     var assetMetadata = new ContentItemAssetMetadata
                     {
-                        Extension = fileSource.Extension ?? file.Extension,
+                        Extension = assetSource.InferExtension(),
                         Identifier = fileSource.Identifier.Value,
                         LastModified = fileSource.LastModified ?? dateTimeNowService.GetDateTimeNow(),
                         Name = fileSource.Name ?? file.Name,
@@ -77,7 +77,7 @@ internal class AssetManager(
 
                     var assetMetadata = new ContentItemAssetMetadata
                     {
-                        Extension = urlSource.Extension,
+                        Extension = assetSource.InferExtension(),
                         Identifier = urlSource.Identifier.Value,
                         LastModified = urlSource.LastModified ?? dateTimeNowService.GetDateTimeNow(),
                         Name = urlSource.Name,


### PR DESCRIPTION
Fix: Fix content hub previews of items with image asset

# Motivation

Fix of https://github.com/orgs/Kentico/projects/15/views/1?pane=issue&itemId=87721943 

## Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
