### PR TITLE
Extend UMT automatic tests

### DIFF
--- a/docs/Samples/basic.json
+++ b/docs/Samples/basic.json
@@ -1276,6 +1276,218 @@
   },
   {
     "$type": "ContentItemSimplified",
+    "ContentItemGUID": "8e957ecc-083b-4c86-b761-8db516c13737",
+    "ContentItemContentFolderGUID": null,
+    "IsSecured": false,
+    "ContentTypeName": "UMT.Article",
+    "Name": "SimplifiedModelSampleAsSubPage4",
+    "IsReusable": false,
+    "ChannelName": "websitechannelExample",
+    "LanguageData": [
+      {
+        "LanguageName": "en-US",
+        "DisplayName": "Simplified model sample sub page 4 - en-US",
+        "VersionStatus": 0,
+        "IsLatest": true,
+        "UserGuid": "dbfcc244-2cb9-4934-857f-9d75404c1553",
+        "ScheduledPublishWhen": "2045-01-01T00:00:00Z",
+        "ScheduledUnpublishWhen": null,
+        "ContentItemData": {
+          "ArticleTitle": "en-US UMT simplified model creation as sub page 4",
+          "ArticleText": "This article is only example of creation UMT simplified model for en-US language",
+          "RelatedArticles": null,
+          "RelatedFaq": null
+        }
+      }
+    ],
+    "PageData": {
+      "PageUrls": [
+        {
+          "UrlPath": "en-us/simplified-sample/sub-page-4",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-US"
+        },
+        {
+          "UrlPath": "en-gb/simplified-sample/sub-page-4",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-GB"
+        },
+        {
+          "UrlPath": "es-cu/simplified-sample/sub-page-4",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "es-CU"
+        }
+      ],
+      "PageGuid": null,
+      "ParentGuid": "4ea03de4-977e-48aa-9340-babf3d23bafa",
+      "TreePath": "/simplified-sample/sub-page-4",
+      "ItemOrder": null
+    }
+  },
+  {
+    "$type": "ContentItemSimplified",
+    "ContentItemGUID": "bb5c0eb4-e688-4a97-99c7-fa97cad8f1d5",
+    "ContentItemContentFolderGUID": null,
+    "IsSecured": false,
+    "ContentTypeName": "UMT.Article",
+    "Name": "SimplifiedModelSampleAsSubPage5",
+    "IsReusable": false,
+    "ChannelName": "websitechannelExample",
+    "LanguageData": [
+      {
+        "LanguageName": "en-US",
+        "DisplayName": "Simplified model sample sub page 5 - en-US",
+        "VersionStatus": 0,
+        "IsLatest": true,
+        "UserGuid": "dbfcc244-2cb9-4934-857f-9d75404c1553",
+        "ScheduledPublishWhen": "2045-01-01T00:00:00Z",
+        "ScheduledUnpublishWhen": null,
+        "ContentItemData": {
+          "ArticleTitle": "en-US UMT simplified model creation as sub page 5",
+          "ArticleText": "This article is only example of creation UMT simplified model for en-US language",
+          "RelatedArticles": null,
+          "RelatedFaq": null
+        }
+      }
+    ],
+    "PageData": {
+      "PageUrls": [
+        {
+          "UrlPath": "en-us/simplified-sample/sub-page-5",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-US"
+        },
+        {
+          "UrlPath": "en-gb/simplified-sample/sub-page-5",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-GB"
+        },
+        {
+          "UrlPath": "es-cu/simplified-sample/sub-page-5",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "es-CU"
+        }
+      ],
+      "PageGuid": null,
+      "ParentGuid": "4ea03de4-977e-48aa-9340-babf3d23bafa",
+      "TreePath": "/simplified-sample/sub-page-5",
+      "ItemOrder": null
+    }
+  },
+  {
+    "$type": "ContentItemSimplified",
+    "ContentItemGUID": "1d542076-dd88-4c13-a8aa-0ffecdabba69",
+    "ContentItemContentFolderGUID": null,
+    "IsSecured": false,
+    "ContentTypeName": "UMT.Article",
+    "Name": "SimplifiedModelSampleAsSubPage6",
+    "IsReusable": false,
+    "ChannelName": "websitechannelExample",
+    "LanguageData": [
+      {
+        "LanguageName": "en-US",
+        "DisplayName": "Simplified model sample sub page 6 - en-US",
+        "VersionStatus": 0,
+        "IsLatest": true,
+        "UserGuid": "dbfcc244-2cb9-4934-857f-9d75404c1553",
+        "ScheduledPublishWhen": null,
+        "ScheduledUnpublishWhen": null,
+        "ContentItemData": {
+          "ArticleTitle": "en-US UMT simplified model creation as sub page 6",
+          "ArticleText": "This article is only example of creation UMT simplified model for en-US language",
+          "RelatedArticles": null,
+          "RelatedFaq": null
+        }
+      }
+    ],
+    "PageData": {
+      "PageUrls": [
+        {
+          "UrlPath": "en-us/simplified-sample/sub-page-6",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-US"
+        },
+        {
+          "UrlPath": "en-gb/simplified-sample/sub-page-6",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-GB"
+        },
+        {
+          "UrlPath": "es-cu/simplified-sample/sub-page-6",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "es-CU"
+        }
+      ],
+      "PageGuid": null,
+      "ParentGuid": "4ea03de4-977e-48aa-9340-babf3d23bafa",
+      "TreePath": "/simplified-sample/sub-page-6",
+      "ItemOrder": null
+    }
+  },
+  {
+    "$type": "ContentItemSimplified",
+    "ContentItemGUID": "fb66242f-4186-4f71-b0b8-fc68b51d52c1",
+    "ContentItemContentFolderGUID": null,
+    "IsSecured": false,
+    "ContentTypeName": "UMT.Article",
+    "Name": "SimplifiedModelSampleAsSubPage7",
+    "IsReusable": false,
+    "ChannelName": "websitechannelExample",
+    "LanguageData": [
+      {
+        "LanguageName": "en-US",
+        "DisplayName": "Simplified model sample sub page 7 - en-US",
+        "VersionStatus": 0,
+        "IsLatest": true,
+        "UserGuid": "dbfcc244-2cb9-4934-857f-9d75404c1553",
+        "ScheduledPublishWhen": "2045-01-01T00:00:00Z",
+        "ScheduledUnpublishWhen": null,
+        "ContentItemData": {
+          "ArticleTitle": "en-US UMT simplified model creation as sub page 7",
+          "ArticleText": "This article is only example of creation UMT simplified model for en-US language",
+          "RelatedArticles": null,
+          "RelatedFaq": null
+        }
+      }
+    ],
+    "PageData": {
+      "PageUrls": [
+        {
+          "UrlPath": "en-us/simplified-sample/sub-page-7",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-US"
+        },
+        {
+          "UrlPath": "en-gb/simplified-sample/sub-page-7",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-GB"
+        },
+        {
+          "UrlPath": "es-cu/simplified-sample/sub-page-7",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "es-CU"
+        }
+      ],
+      "PageGuid": null,
+      "ParentGuid": "4ea03de4-977e-48aa-9340-babf3d23bafa",
+      "TreePath": "/simplified-sample/sub-page-7",
+      "ItemOrder": null
+    }
+  },
+  {
+    "$type": "ContentItemSimplified",
     "ContentItemGUID": "f9cb9484-ce90-460f-a5c8-ad953e2b9286",
     "ContentItemContentFolderGUID": "ae29c1d1-217a-45da-8b30-585d1881387e",
     "IsSecured": false,

--- a/examples/Kentico.Xperience.UMT.Example.AdminApp/Data/Samples.json
+++ b/examples/Kentico.Xperience.UMT.Example.AdminApp/Data/Samples.json
@@ -1276,6 +1276,218 @@
   },
   {
     "$type": "ContentItemSimplified",
+    "ContentItemGUID": "8e957ecc-083b-4c86-b761-8db516c13737",
+    "ContentItemContentFolderGUID": null,
+    "IsSecured": false,
+    "ContentTypeName": "UMT.Article",
+    "Name": "SimplifiedModelSampleAsSubPage4",
+    "IsReusable": false,
+    "ChannelName": "websitechannelExample",
+    "LanguageData": [
+      {
+        "LanguageName": "en-US",
+        "DisplayName": "Simplified model sample sub page 4 - en-US",
+        "VersionStatus": 0,
+        "IsLatest": true,
+        "UserGuid": "dbfcc244-2cb9-4934-857f-9d75404c1553",
+        "ScheduledPublishWhen": "2045-01-01T00:00:00Z",
+        "ScheduledUnpublishWhen": null,
+        "ContentItemData": {
+          "ArticleTitle": "en-US UMT simplified model creation as sub page 4",
+          "ArticleText": "This article is only example of creation UMT simplified model for en-US language",
+          "RelatedArticles": null,
+          "RelatedFaq": null
+        }
+      }
+    ],
+    "PageData": {
+      "PageUrls": [
+        {
+          "UrlPath": "en-us/simplified-sample/sub-page-4",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-US"
+        },
+        {
+          "UrlPath": "en-gb/simplified-sample/sub-page-4",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-GB"
+        },
+        {
+          "UrlPath": "es-cu/simplified-sample/sub-page-4",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "es-CU"
+        }
+      ],
+      "PageGuid": null,
+      "ParentGuid": "4ea03de4-977e-48aa-9340-babf3d23bafa",
+      "TreePath": "/simplified-sample/sub-page-4",
+      "ItemOrder": null
+    }
+  },
+  {
+    "$type": "ContentItemSimplified",
+    "ContentItemGUID": "bb5c0eb4-e688-4a97-99c7-fa97cad8f1d5",
+    "ContentItemContentFolderGUID": null,
+    "IsSecured": false,
+    "ContentTypeName": "UMT.Article",
+    "Name": "SimplifiedModelSampleAsSubPage5",
+    "IsReusable": false,
+    "ChannelName": "websitechannelExample",
+    "LanguageData": [
+      {
+        "LanguageName": "en-US",
+        "DisplayName": "Simplified model sample sub page 5 - en-US",
+        "VersionStatus": 0,
+        "IsLatest": true,
+        "UserGuid": "dbfcc244-2cb9-4934-857f-9d75404c1553",
+        "ScheduledPublishWhen": "2045-01-01T00:00:00Z",
+        "ScheduledUnpublishWhen": null,
+        "ContentItemData": {
+          "ArticleTitle": "en-US UMT simplified model creation as sub page 5",
+          "ArticleText": "This article is only example of creation UMT simplified model for en-US language",
+          "RelatedArticles": null,
+          "RelatedFaq": null
+        }
+      }
+    ],
+    "PageData": {
+      "PageUrls": [
+        {
+          "UrlPath": "en-us/simplified-sample/sub-page-5",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-US"
+        },
+        {
+          "UrlPath": "en-gb/simplified-sample/sub-page-5",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-GB"
+        },
+        {
+          "UrlPath": "es-cu/simplified-sample/sub-page-5",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "es-CU"
+        }
+      ],
+      "PageGuid": null,
+      "ParentGuid": "4ea03de4-977e-48aa-9340-babf3d23bafa",
+      "TreePath": "/simplified-sample/sub-page-5",
+      "ItemOrder": null
+    }
+  },
+  {
+    "$type": "ContentItemSimplified",
+    "ContentItemGUID": "1d542076-dd88-4c13-a8aa-0ffecdabba69",
+    "ContentItemContentFolderGUID": null,
+    "IsSecured": false,
+    "ContentTypeName": "UMT.Article",
+    "Name": "SimplifiedModelSampleAsSubPage6",
+    "IsReusable": false,
+    "ChannelName": "websitechannelExample",
+    "LanguageData": [
+      {
+        "LanguageName": "en-US",
+        "DisplayName": "Simplified model sample sub page 6 - en-US",
+        "VersionStatus": 0,
+        "IsLatest": true,
+        "UserGuid": "dbfcc244-2cb9-4934-857f-9d75404c1553",
+        "ScheduledPublishWhen": null,
+        "ScheduledUnpublishWhen": null,
+        "ContentItemData": {
+          "ArticleTitle": "en-US UMT simplified model creation as sub page 6",
+          "ArticleText": "This article is only example of creation UMT simplified model for en-US language",
+          "RelatedArticles": null,
+          "RelatedFaq": null
+        }
+      }
+    ],
+    "PageData": {
+      "PageUrls": [
+        {
+          "UrlPath": "en-us/simplified-sample/sub-page-6",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-US"
+        },
+        {
+          "UrlPath": "en-gb/simplified-sample/sub-page-6",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-GB"
+        },
+        {
+          "UrlPath": "es-cu/simplified-sample/sub-page-6",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "es-CU"
+        }
+      ],
+      "PageGuid": null,
+      "ParentGuid": "4ea03de4-977e-48aa-9340-babf3d23bafa",
+      "TreePath": "/simplified-sample/sub-page-6",
+      "ItemOrder": null
+    }
+  },
+  {
+    "$type": "ContentItemSimplified",
+    "ContentItemGUID": "fb66242f-4186-4f71-b0b8-fc68b51d52c1",
+    "ContentItemContentFolderGUID": null,
+    "IsSecured": false,
+    "ContentTypeName": "UMT.Article",
+    "Name": "SimplifiedModelSampleAsSubPage7",
+    "IsReusable": false,
+    "ChannelName": "websitechannelExample",
+    "LanguageData": [
+      {
+        "LanguageName": "en-US",
+        "DisplayName": "Simplified model sample sub page 7 - en-US",
+        "VersionStatus": 0,
+        "IsLatest": true,
+        "UserGuid": "dbfcc244-2cb9-4934-857f-9d75404c1553",
+        "ScheduledPublishWhen": "2045-01-01T00:00:00Z",
+        "ScheduledUnpublishWhen": null,
+        "ContentItemData": {
+          "ArticleTitle": "en-US UMT simplified model creation as sub page 7",
+          "ArticleText": "This article is only example of creation UMT simplified model for en-US language",
+          "RelatedArticles": null,
+          "RelatedFaq": null
+        }
+      }
+    ],
+    "PageData": {
+      "PageUrls": [
+        {
+          "UrlPath": "en-us/simplified-sample/sub-page-7",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-US"
+        },
+        {
+          "UrlPath": "en-gb/simplified-sample/sub-page-7",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "en-GB"
+        },
+        {
+          "UrlPath": "es-cu/simplified-sample/sub-page-7",
+          "PathIsDraft": false,
+          "PathIsLatest": true,
+          "LanguageName": "es-CU"
+        }
+      ],
+      "PageGuid": null,
+      "ParentGuid": "4ea03de4-977e-48aa-9340-babf3d23bafa",
+      "TreePath": "/simplified-sample/sub-page-7",
+      "ItemOrder": null
+    }
+  },
+  {
+    "$type": "ContentItemSimplified",
     "ContentItemGUID": "f9cb9484-ce90-460f-a5c8-ad953e2b9286",
     "ContentItemContentFolderGUID": "ae29c1d1-217a-45da-8b30-585d1881387e",
     "IsSecured": false,

--- a/examples/Kentico.Xperience.UMT.Examples/SampleProvider.cs
+++ b/examples/Kentico.Xperience.UMT.Examples/SampleProvider.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+
 using Kentico.Xperience.UMT.Model;
 using Kentico.Xperience.UMT.Services;
 
@@ -32,14 +33,15 @@ public static class SampleProvider
         Samples.TryGetValue(sampleName, out var sample) && sample.Sample.Value is UmtModel model
             ? new SerializedSampleInfo(sample.Header, sample.Description, importService.SerializeToJson(model, new JsonSerializerOptions
             {
-                WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             }))
             : null;
 
     public static List<IUmtModel> GetFullSample()
     {
         var sourceData = new List<IUmtModel>();
-        
+
         // taxonomy samples
         sourceData.AddRange([
             TaxonomySamples.SampleTaxonomyCoffee,
@@ -48,7 +50,7 @@ public static class SampleProvider
             TaxonomySamples.SampleTagCoffeaRobusta,
             TaxonomySamples.SampleTagCoffeaArabica,
         ]);
-        
+
         // sample data
         sourceData.AddRange([
             UserSamples.SampleAdministrator,
@@ -64,34 +66,34 @@ public static class SampleProvider
             ChannelSamples.SampleChannelForWebSiteChannel,
             EmailChannelSamples.SampleEmailChannel,
             WebSiteChannelSamples.SampleWebSiteChannel,
-    
+
             DataClassSamples.ArticleClassSample,
             DataClassSamples.ArticleAssignedToWebSiteChannel,
             DataClassSamples.FaqDataClass,
             DataClassSamples.EventDataClass,
-    
+
             ContentItemSamples.SampleContentItem,
             ContentItemLanguageMetadataSamples.SampleContentItemLanguageMetadataBasic,
             ContentItemLanguageMetadataSamples.SampleContentItemLanguageMetadata,
-    
+
             WebPageContentItemSamples.SampleWebPageItem,
 
             AssetSamples.SampleMediaLibrary,
             AssetSamples.SampleMediaFile,
             AssetSamples.SampleMediaFileFromUri
         ]);
-        
+
         // sample reusable content item
         sourceData.AddRange(new IUmtModel[]
         {
             ContentItemSamples.SampleFaqContentItem,
-    
+
             ContentItemSamples.SampleFaqContentItemCommonDataEnUs,
             ContentItemSamples.SampleFaqContentItemCommonDataEnGb,
-    
+
             ContentItemSamples.SampleFaqDataEnUs,
             ContentItemSamples.SampleFaqDataEnGb,
-    
+
             ContentItemSamples.SampleFaqContentItemLanguageMetadataEnUs,
             ContentItemSamples.SampleFaqContentItemLanguageMetadataEnGb,
         });
@@ -100,23 +102,23 @@ public static class SampleProvider
         sourceData.AddRange(new IUmtModel[]
         {
             ContentItemSamples.SampleArticleContentItem,
-    
+
             ContentItemSamples.SampleArticleContentItemCommonDataEnUs,
             ContentItemSamples.SampleArticleContentItemCommonDataEnGb,
-    
+
             ContentItemSamples.SampleArticleDataEnUs,
             ContentItemSamples.SampleArticleDataEnGb,
-    
+
             ContentItemSamples.SampleArticleContentItemLanguageMetadataEnUs,
             ContentItemSamples.SampleArticleContentItemLanguageMetadataEnGb,
             ContentItemSamples.SampleArticleWebPathUrlPathModelEnUs,
             ContentItemSamples.SampleArticleWebPathUrlPathModelEnGb,
             ContentItemSamples.SampleArticleWebPathUrlPathModelEs,
-    
+
             ContentItemSamples.SampleArticleWebPageItem,
             ContentItemSamples.SampleArticleWebPageAcl
         });
-        
+
         sourceData.AddRange(new IUmtModel[]
         {
             ContentItemSamples.SampleArticleContentItemWithRelations, ContentItemSamples.SampleArticleContentItemCommonDataEnUsWithRelations, ContentItemSamples.SampleArticleContentItemCommonDataEnGbWithRelations, ContentItemSamples.SampleArticleDataEnUsWithRelations,
@@ -129,20 +131,24 @@ public static class SampleProvider
             ContentItemSamples.SampleArticleWebPageUrlWithRelations,
             ContentItemSamples.SampleArticleWebPageUrlWithRelationsEs
         });
-        
+
         // folder samples
         sourceData.AddRange([
             ContentFolderSamples.SampleContentFolder,
             ContentFolderSamples.SampleContentSubFolder,
         ]);
-        
+
         sourceData.Add(ContentItemSimplifiedSamples.SampleArticleContentItemSimplifiedModel);
         sourceData.Add(ContentItemSimplifiedSamples.SampleArticleSubPageContentItemSimplifiedModel);
         sourceData.Add(ContentItemSimplifiedSamples.SampleArticleSubPage2ContentItemSimplifiedModel_Draft);
         sourceData.Add(ContentItemSimplifiedSamples.SampleArticleSubPage3ContentItemSimplifiedModel_Draft);
+        sourceData.Add(ContentItemSimplifiedSamples.SampleArticleSubPage4ContentItemSimplifiedModel_Scheduled);
+        sourceData.Add(ContentItemSimplifiedSamples.SampleArticleSubPage5ContentItemSimplifiedModel_Scheduled);
+        sourceData.Add(ContentItemSimplifiedSamples.SampleArticleSubPage6ContentItemSimplifiedModel_InitialDraft);
+        sourceData.Add(ContentItemSimplifiedSamples.SampleArticleSubPage7ContentItemSimplifiedModel_Scheduled);
         sourceData.Add(ContentItemSimplifiedSamples.SampleFaqContentItemSimplifiedModel); // references sample content subfolder
         sourceData.Add(ContentItemSimplifiedSamples.SampleEventContentItemWithAsset);
-        
+
         return sourceData;
     }
 }

--- a/examples/Kentico.Xperience.UMT.Examples/Samples/ContentItemSimplifiedSamples.cs
+++ b/examples/Kentico.Xperience.UMT.Examples/Samples/ContentItemSimplifiedSamples.cs
@@ -1,21 +1,25 @@
 ﻿using CMS.ContentEngine;
-using CMS.ContentEngine.Internal;
 
 using Kentico.Xperience.UMT.Model;
+using Kentico.Xperience.UMT.Utils;
 
 namespace Kentico.Xperience.UMT.Examples;
 
 public static class ContentItemSimplifiedSamples
 {
-    public static readonly Guid SampleArticleContentItemGuid = new Guid("37C3F5DD-6F2A-4EFF-B46E-A36EDDEBF572");
-    public static readonly Guid SampleFaqContentItemGuid = new Guid("F9CB9484-CE90-460F-A5C8-AD953E2B9286");
-    public static readonly Guid SampleEvent2024ContentItemGuid = new Guid("C82CDC96-65EC-4F4C-AEC2-3D657E6D5CE1");
+    public static readonly Guid SampleArticleContentItemGuid = new("37C3F5DD-6F2A-4EFF-B46E-A36EDDEBF572");
+    public static readonly Guid SampleFaqContentItemGuid = new("F9CB9484-CE90-460F-A5C8-AD953E2B9286");
+    public static readonly Guid SampleEvent2024ContentItemGuid = new("C82CDC96-65EC-4F4C-AEC2-3D657E6D5CE1");
 
-    public static readonly Guid SampleArticleWebPageGuid = new Guid("4EA03DE4-977E-48AA-9340-BABF3D23BAFA");
+    public static readonly Guid SampleArticleWebPageGuid = new("4EA03DE4-977E-48AA-9340-BABF3D23BAFA");
 
-    public static readonly Guid SampleArticleSubPageContentItemGuid = new Guid("9ED8DE86-859C-4F6C-94F2-CDD6BAED99FE");
-    public static readonly Guid SampleArticleSubPage2ContentItemGuid = new Guid("017EDC1E-95C6-43E4-89D5-716C6AE594B2");
-    public static readonly Guid SampleArticleSubPage3ContentItemGuid = new Guid("73298F71-0BB1-4083-A674-A876769E3DD9");
+    public static readonly Guid SampleArticleSubPageContentItemGuid = new("9ED8DE86-859C-4F6C-94F2-CDD6BAED99FE");
+    public static readonly Guid SampleArticleSubPage2ContentItemGuid = new("017EDC1E-95C6-43E4-89D5-716C6AE594B2");
+    public static readonly Guid SampleArticleSubPage3ContentItemGuid = new("73298F71-0BB1-4083-A674-A876769E3DD9");
+    public static readonly Guid SampleArticleSubPage4ContentItemGuid = new("8E957ECC-083B-4C86-B761-8DB516C13737");
+    public static readonly Guid SampleArticleSubPage5ContentItemGuid = new("BB5C0EB4-E688-4A97-99C7-FA97CAD8F1D5");
+    public static readonly Guid SampleArticleSubPage6ContentItemGuid = new("1D542076-DD88-4C13-A8AA-0FFECDABBA69");
+    public static readonly Guid SampleArticleSubPage7ContentItemGuid = new("FB66242F-4186-4F71-B0B8-FC68B51D52C1");
 
     [Sample("ContentItemSimplifiedModel.Sample.Article", "Simplified model for importing webpage content item", "Simplified model for webpage content item sample")]
     public static ContentItemSimplifiedModel SampleArticleContentItemSimplifiedModel => new()
@@ -71,7 +75,7 @@ public static class ContentItemSimplifiedSamples
                         new {Identifier = TaxonomySamples.SampleTagCoffeaRobustaGuid},
                     })
                 },
-                ScheduledPublishWhen = new DateTime(2045, 1, 1, 0,0,0,0,0, DateTimeKind.Utc)
+                ScheduledPublishWhen = new DateTime(2045, 1, 1, 0, 0, 0, 0, 0, DateTimeKind.Utc)
             },
             new()
             {
@@ -91,7 +95,7 @@ public static class ContentItemSimplifiedSamples
                         new {Identifier = TaxonomySamples.SampleTagCoffeaRobustaGuid},
                     })
                 },
-                ScheduledUnpublishWhen = new DateTime(2045, 1, 1, 0,0,0,0,0, DateTimeKind.Utc)
+                ScheduledUnpublishWhen = new DateTime(2045, 1, 1, 0, 0, 0, 0, 0, DateTimeKind.Utc)
             }
         ],
     };
@@ -112,7 +116,7 @@ public static class ContentItemSimplifiedSamples
                 ParentGuid = SampleArticleWebPageGuid,
                 TreePath = treePath,
                 PageUrls = [
-                    ..languageData.Select(languageVersion => new PageUrlModel
+                    .. languageData.Select(languageVersion => new PageUrlModel
                     {
                         LanguageName = languageVersion.Language,
                         UrlPath = $"{languageVersion.Language.ToLower()}{treePath}{(languageVersion.Status == VersionStatus.Draft ? "-new-draft" : string.Empty)}",
@@ -120,8 +124,9 @@ public static class ContentItemSimplifiedSamples
                         PathIsLatest = languageVersion.IsLatest
                     }),
                     // Reserved URLs for language mutations not yet created
-                    ..ContentLanguageSamples.Languages.Select(x => x.ContentLanguageName).Except(languageData.Select(x => x.Language))
-                        .Select(language => new PageUrlModel {
+                    .. ContentLanguageSamples.Languages.Select(x => x.ContentLanguageName).Except(languageData.Select(x => x.Language))
+                        .Select(language => new PageUrlModel
+                        {
                             LanguageName = language,
                             PathIsDraft = false,
                             PathIsLatest = true,
@@ -197,6 +202,63 @@ public static class ContentItemSimplifiedSamples
             ]
         );
 
+    [Sample("ContentItemSimplifiedModel.Sample.ArticleSubPage4", "Simplified model for importing webpage content item with parent", "Simplified model for webpage content item sample with parent")]
+    public static ContentItemSimplifiedModel SampleArticleSubPage4ContentItemSimplifiedModel_Scheduled =>
+        CreateSampleContentItemSimplifiedModel(
+            contentItemGuid: SampleArticleSubPage4ContentItemGuid,
+            name: "SimplifiedModelSampleAsSubPage4",
+            displayName: "Simplified model sample sub page 4",
+            treePath: "/simplified-sample/sub-page-4",
+            title: "UMT simplified model creation as sub page 4",
+            articleText: "This article is only example of creation UMT simplified model",
+            [
+                (ContentLanguageSamples.SampleContentLanguageEnUs.ContentLanguageName!, VersionStatus.InitialDraft, true, new Guid("6DFB0834-B61A-4E79-8E12-09E40019FD1D")),
+            ]
+        ).Apply(x => x.LanguageData.ForEach(ld => ld.ScheduledPublishWhen = new DateTime(2045, 1, 1, 0, 0, 0, 0, 0, DateTimeKind.Utc)));
+
+    [Sample("ContentItemSimplifiedModel.Sample.ArticleSubPage5", "Simplified model for importing webpage content item with parent", "Simplified model for webpage content item sample with parent")]
+    public static ContentItemSimplifiedModel SampleArticleSubPage5ContentItemSimplifiedModel_Scheduled =>
+        CreateSampleContentItemSimplifiedModel(
+            contentItemGuid: SampleArticleSubPage5ContentItemGuid,
+            name: "SimplifiedModelSampleAsSubPage5",
+            displayName: "Simplified model sample sub page 5",
+            treePath: "/simplified-sample/sub-page-5",
+            title: "UMT simplified model creation as sub page 5",
+            articleText: "This article is only example of creation UMT simplified model",
+            [
+                (ContentLanguageSamples.SampleContentLanguageEnUs.ContentLanguageName!, VersionStatus.InitialDraft, true, new Guid("BD7C71FF-7953-45B4-B43D-F2926D022157")),
+            ]
+        ).Apply(x => x.LanguageData.ForEach(ld => ld.ScheduledPublishWhen = new DateTime(2045, 1, 1, 0, 0, 0, 0, 0, DateTimeKind.Utc)));
+
+    [Sample("ContentItemSimplifiedModel.Sample.ArticleSubPage6", "Simplified model for importing webpage content item with parent, in Initial Draft", "Simplified model for webpage content item sample with parent")]
+    public static ContentItemSimplifiedModel SampleArticleSubPage6ContentItemSimplifiedModel_InitialDraft =>
+        CreateSampleContentItemSimplifiedModel(
+            contentItemGuid: SampleArticleSubPage6ContentItemGuid,
+            name: "SimplifiedModelSampleAsSubPage6",
+            displayName: "Simplified model sample sub page 6",
+            treePath: "/simplified-sample/sub-page-6",
+            title: "UMT simplified model creation as sub page 6",
+            articleText: "This article is only example of creation UMT simplified model",
+            [
+                (ContentLanguageSamples.SampleContentLanguageEnUs.ContentLanguageName!, VersionStatus.InitialDraft, true, new Guid("22DDD031-C3EF-4079-8E91-6AF58EDA291F")),
+            ]
+        );
+
+    [Sample("ContentItemSimplifiedModel.Sample.ArticleSubPage7", "Simplified model for importing webpage content item with parent", "Simplified model for webpage content item sample with parent")]
+    public static ContentItemSimplifiedModel SampleArticleSubPage7ContentItemSimplifiedModel_Scheduled =>
+        CreateSampleContentItemSimplifiedModel(
+            contentItemGuid: SampleArticleSubPage7ContentItemGuid,
+            name: "SimplifiedModelSampleAsSubPage7",
+            displayName: "Simplified model sample sub page 7",
+            treePath: "/simplified-sample/sub-page-7",
+            title: "UMT simplified model creation as sub page 7",
+            articleText: "This article is only example of creation UMT simplified model",
+            [
+                (ContentLanguageSamples.SampleContentLanguageEnUs.ContentLanguageName!, VersionStatus.InitialDraft, true, new Guid("6AE7CB81-D03F-43AF-9F3F-EA3DBD9983B5")),
+            ]
+        ).Apply(x => x.LanguageData.ForEach(ld => ld.ScheduledPublishWhen = new DateTime(2045, 1, 1, 0, 0, 0, 0, 0, DateTimeKind.Utc)));
+
+
     [Sample("ContentItemSimplifiedModel.Sample.Faq", "This sample describes how to create content item data inside XbyK", "Simplified model for reusable content item sample")]
     public static ContentItemSimplifiedModel SampleFaqContentItemSimplifiedModel => new()
     {
@@ -231,7 +293,7 @@ public static class ContentItemSimplifiedSamples
                     ["FaqQuestion"] = "en-GB FAQ question text (reusable)",
                     ["FaqAnswer"] = "en-GB FAQ answer text (reusable)"
                 },
-                ScheduledUnpublishWhen = new DateTime(2045, 1, 1, 0,0,0,0,0, DateTimeKind.Utc)
+                ScheduledUnpublishWhen = new DateTime(2045, 1, 1, 0, 0, 0, 0, 0, DateTimeKind.Utc)
             }
         ],
     };
@@ -257,7 +319,7 @@ public static class ContentItemSimplifiedSamples
                 {
                     ["EventTitle"] = "en-US Event sample 2024",
                     ["EventText"] = "en-US Event sample 2024 (reusable)",
-                    ["EventDate"] = new DateTime(2024,1,1,0,0,0,0, DateTimeKind.Utc),
+                    ["EventDate"] = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
                     ["EventRecurrentYearly"] = true,
                     ["EventTeaser"] = new AssetDataSource
                     {
@@ -281,7 +343,7 @@ public static class ContentItemSimplifiedSamples
                 {
                     ["EventTitle"] = "en-GB Event sample 2024",
                     ["EventText"] = "en-GB Event sample 2024 (reusable)",
-                    ["EventDate"] = new DateTime(2024,1,1,0,0,0,0, DateTimeKind.Utc),
+                    ["EventDate"] = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
                     ["EventRecurrentYearly"] = true,
                     ["EventTeaser"] = new AssetUrlSource
                     {
@@ -294,7 +356,7 @@ public static class ContentItemSimplifiedSamples
                         Url = "https://devnet.kentico.com/DevNet/media/devnet/cms_screen.jpg"
                     },
                 },
-                ScheduledUnpublishWhen = new DateTime(2045, 1, 1, 0,0,0,0,0, DateTimeKind.Utc)
+                ScheduledUnpublishWhen = new DateTime(2045, 1, 1, 0, 0, 0, 0, 0, DateTimeKind.Utc)
             }
         ],
     };

--- a/src/Kentico.Xperience.UMT/InfoAdapter/ContentItemSimplifiedAdapter.cs
+++ b/src/Kentico.Xperience.UMT/InfoAdapter/ContentItemSimplifiedAdapter.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using System.Text.Json;
+﻿using System.Text.Json;
 
 using CMS.ContentEngine;
 using CMS.ContentEngine.Internal;
@@ -11,14 +10,11 @@ using CMS.Helpers;
 using CMS.Membership;
 using CMS.Websites;
 using CMS.Websites.Internal;
-using CMS.Websites.Routing.Internal;
 
 using Kentico.Xperience.UMT.Model;
 using Kentico.Xperience.UMT.ProviderProxy;
-using Kentico.Xperience.UMT.Utils;
 
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Kentico.Xperience.UMT.InfoAdapter;
 
@@ -55,7 +51,7 @@ public class ContentItemSimplifiedAdapter : IInfoAdapter<ContentItemInfo, IUmtMo
         }
 
         using var scope = new CMSTransactionScope();
-        
+
         ArgumentNullException.ThrowIfNull(cim.ContentItemGUID);
         var existingContentItem = ProviderProxy.GetBaseInfoByGuid(cim.ContentItemGUID.Value, cim) as ContentItemInfo;
 
@@ -94,8 +90,6 @@ public class ContentItemSimplifiedAdapter : IInfoAdapter<ContentItemInfo, IUmtMo
 
         var contentLanguageProxy = providerProxyFactory.CreateProviderProxy<ContentLanguageInfo>(new ProviderProxyContext());
         var userInfoProxy = providerProxyFactory.CreateProviderProxy<UserInfo>(new ProviderProxyContext());
-
-        var commonDataModelsByLang = new Dictionary<string, List<ContentItemCommonDataModel>>();
 
         foreach (var languageData in cim.LanguageData)
         {

--- a/tests/Kentico.Xperience.UMT.Tests/Extensions/PlaywrightExtensions.cs
+++ b/tests/Kentico.Xperience.UMT.Tests/Extensions/PlaywrightExtensions.cs
@@ -1,14 +1,48 @@
-﻿using Microsoft.Playwright;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
+
+using Microsoft.Playwright;
 
 namespace TestAfterMigration.Extensions
 {
     public static class PlaywrightExtensions
     {
         public static Task WaitForVisible(this ILocator locator) => locator.Nth(0).WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+
+        /// <summary>
+        /// Ensures all page loading processes have ended by monitoring that nothing more happens. 
+        /// Duration is at least <paramref name="stableDelayMs"/>, so use only when needed if you
+        /// have a lot of tests.
+        /// </summary>
+        /// <param name="page"></param>
+        /// <param name="pollDelayMs"></param>
+        /// <param name="stableDelayMs"></param>
+        /// <returns></returns>
+        public static async Task Debounce(this IPage page, int pollDelayMs = 100, int stableDelayMs = 500)
+        {
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+            string markupPrevious = "";
+            var stopwatch = Stopwatch.StartNew();
+            bool isStable = false;
+            while (!isStable)
+            {
+                string markupCurrent = await page.ContentAsync();
+                if (markupCurrent == markupPrevious)
+                {
+                    double elapsed = stopwatch.ElapsedMilliseconds;
+                    isStable = stableDelayMs <= elapsed;
+                }
+                else
+                {
+                    markupPrevious = markupCurrent;
+                    stopwatch.Restart();
+                }
+                if (!isStable)
+                {
+                    await Task.Delay(pollDelayMs);
+                }
+            }
+        }
+
     }
 }

--- a/tests/Kentico.Xperience.UMT.Tests/Helpers/PageTreeItem.cs
+++ b/tests/Kentico.Xperience.UMT.Tests/Helpers/PageTreeItem.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Playwright;
+
 using TestAfterMigration.Extensions;
 
 namespace TestAfterMigration.Helpers
@@ -12,10 +13,18 @@ namespace TestAfterMigration.Helpers
         public IEnumerable<PageTreeItem> Children { get; set; } = [];
         public ILocator TitleElement => Locator.GetByTestId("tree-item-title").Nth(0);
         public Task ClickAsync() => TitleElement.ClickAsync();
+
+        /// <summary>
+        /// Beware this method doesn't work when name is too long, 
+        /// because ellipsis is rendered instead of full page name, 
+        /// which this method requires
+        /// </summary>
+        /// <returns></returns>
         public async Task WaitBreadcrumbsLoaded()
         {
-            string pageTitle = (await Locator.GetByTestId("tree-item-title").Nth(0).TextContentAsync())!;
-            await Locator.Page.GetByTestId("breadcrumbs").GetByText(pageTitle).WaitForVisible();
+            await page.Debounce();
+            await Locator.Page.GetByTestId("breadcrumbs").WaitForVisible();
+            await page.Debounce();
         }
     }
 }

--- a/tests/Kentico.Xperience.UMT.Tests/Tests/AdminTestBase.cs
+++ b/tests/Kentico.Xperience.UMT.Tests/Tests/AdminTestBase.cs
@@ -1,7 +1,5 @@
-
-using System.Diagnostics;
-
 using Microsoft.Playwright;
+
 using TestAfterMigration.Enums;
 using TestAfterMigration.Extensions;
 using TestAfterMigration.Helpers;
@@ -104,7 +102,7 @@ namespace TestAfterMigration.Tests
                 await parentNode.GetByRole(AriaRole.Treeitem).WaitForVisible();
             }
 
-            foreach (var childLocator in (await parentNode.GetByRole(AriaRole.Treeitem).AllAsync()))
+            foreach (var childLocator in await parentNode.GetByRole(AriaRole.Treeitem).AllAsync())
             {
                 var item = new PageTreeItem(parentNode.Page, (await childLocator.GetAttributeAsync("data-testid-nodeid"))!);
                 await item.LoadInfo();
@@ -126,32 +124,7 @@ namespace TestAfterMigration.Tests
         /// <param name="pollDelayMs"></param>
         /// <param name="stableDelayMs"></param>
         /// <returns></returns>
-        protected async Task Debounce(int pollDelayMs = 100, int stableDelayMs = 500)
-        {
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            await Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
-            string markupPrevious = "";
-            var stopwatch = Stopwatch.StartNew();
-            bool isStable = false;
-            while (!isStable)
-            {
-                string markupCurrent = await Page.ContentAsync();
-                if (markupCurrent == markupPrevious)
-                {
-                    double elapsed = stopwatch.ElapsedMilliseconds;
-                    isStable = stableDelayMs <= elapsed;
-                }
-                else
-                {
-                    markupPrevious = markupCurrent;
-                    stopwatch.Restart();
-                }
-                if (!isStable)
-                {
-                    await Task.Delay(pollDelayMs);
-                }
-            }
-        }
+        protected Task Debounce(int pollDelayMs = 100, int stableDelayMs = 500) => Page.Debounce(pollDelayMs, stableDelayMs);
 
         protected async Task AssertNoEventlogErrors()
         {


### PR DESCRIPTION
Add: Extend UMT automatic tests

# Motivation
Increase robustness of testing after introducing ContentItemSimplifiedModel upsert mode

## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
