### PR TITLE
Bump to 30.11.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>$(Company)</Authors>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Xperience by Kentico: Universal Migration Tool (UMT) is an open-source set o
 
 | Xperience Version | Library Version |
 | ----------------- | --------------- |
-| 30.9.0            | >= 3.10.0       |
+| 30.9.0            | >= 3.11.0       |
 | 30.8.0            | >= 3.9.0        |
 | 30.6.0            | >= 3.8.0        |
 | 30.5.1            | >= 3.7.0        |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The Xperience by Kentico: Universal Migration Tool (UMT) is an open-source set o
 
 | Xperience Version | Library Version |
 | ----------------- | --------------- |
+| 30.9.0            | >= 3.10.0       |
 | 30.8.0            | >= 3.9.0        |
 | 30.6.0            | >= 3.8.0        |
 | 30.5.1            | >= 3.7.0        |


### PR DESCRIPTION
This pull request updates the documentation to reflect support for a new version of Xperience.

Documentation update:

* Added a new row to the version compatibility table in `README.md` to indicate that library version `>= 3.11.0` supports Xperience version `30.9.0`.
