### PR TITLE
bump version to 4.0.0 for Xperience 31.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>$(Company)</Authors>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
-    <VersionPrefix>3.14.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 


### PR DESCRIPTION
Version bump to align with Xperience by Kentico 31.0.0 release.

## Changes

- **Directory.Build.props**: `VersionPrefix` updated from `3.14.0` to `4.0.0`


This maintains the established version correspondence pattern between Xperience and UMT releases.
