### PR TITLE
Bump version to v 4.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>$(Company)</Authors>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 


### PR DESCRIPTION
Version bump to align with Xperience by Kentico 31.0.0 release.

## Changes

- **Directory.Build.props**: `VersionPrefix` updated from `4.0.0` to `4.0.1`


This maintains the established version correspondence pattern between Xperience and UMT releases.

