### PR TITLE
ContentItemReference populator fix - exceptions when reference field...

### DIFF
--- a/src/Kentico.Xperience.UMT/Services/ContentItemReferencePopulator.cs
+++ b/src/Kentico.Xperience.UMT/Services/ContentItemReferencePopulator.cs
@@ -89,40 +89,43 @@ namespace Kentico.Xperience.UMT.Services
                 {
                     if (contentItemReferenceFieldValue is string serializedValue)
                     {
-                        var unescapedSerializedValue = Regex.Unescape(serializedValue).Trim('\"');
-
-                        if (field.DataType is SchemaHelper.WEBPAGES_DATA_TYPE_NAME)
+                        if (!string.IsNullOrWhiteSpace(serializedValue))
                         {
-                            var value = JsonSerializer.Deserialize<IEnumerable<WebPageRelatedItem>?>(unescapedSerializedValue, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                            var unescapedSerializedValue = Regex.Unescape(serializedValue).Trim('\"');
 
-                            if (value is not null)
+                            if (field.DataType is SchemaHelper.WEBPAGES_DATA_TYPE_NAME)
                             {
-                                foreach (var targetWebPageGuid in value.Select(x => x.WebPageGuid))
+                                var value = JsonSerializer.Deserialize<IEnumerable<WebPageRelatedItem>?>(unescapedSerializedValue, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+                                if (value is not null)
                                 {
-                                    var targetWebPageItem = CMS.Websites.Internal.WebPageItemInfo.Provider.Get(targetWebPageGuid) ?? throw new ArgumentNullException($"The linked webpage with GUID '{targetWebPageGuid}' referenced by a ContentItemCommonData with GUID '{commonDataInfo.ContentItemCommonDataGUID}' does not exist or could not be found.");
-                                    yield return new()
+                                    foreach (var targetWebPageGuid in value.Select(x => x.WebPageGuid))
                                     {
-                                        ContentItemReferenceGroupGUID = groupGuid,
-                                        ContentItemReferenceSourceCommonDataID = commonDataInfo.ContentItemCommonDataID,
-                                        ContentItemReferenceTargetItemID = targetWebPageItem.WebPageItemContentItemID
-                                    };
+                                        var targetWebPageItem = CMS.Websites.Internal.WebPageItemInfo.Provider.Get(targetWebPageGuid) ?? throw new ArgumentNullException($"The linked webpage with GUID '{targetWebPageGuid}' referenced by a ContentItemCommonData with GUID '{commonDataInfo.ContentItemCommonDataGUID}' does not exist or could not be found.");
+                                        yield return new()
+                                        {
+                                            ContentItemReferenceGroupGUID = groupGuid,
+                                            ContentItemReferenceSourceCommonDataID = commonDataInfo.ContentItemCommonDataID,
+                                            ContentItemReferenceTargetItemID = targetWebPageItem.WebPageItemContentItemID
+                                        };
+                                    }
                                 }
                             }
-                        }
-                        else
-                        {
-                            var value = JsonSerializer.Deserialize<IEnumerable<ContentItemReference>?>(unescapedSerializedValue, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                            if (value is not null)
+                            else
                             {
-                                foreach (var targetItemGuid in value.Select(x => x.Identifier))
+                                var value = JsonSerializer.Deserialize<IEnumerable<ContentItemReference>?>(unescapedSerializedValue, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                                if (value is not null)
                                 {
-                                    var contentItemInfo = ContentItemInfo.Provider.Get(targetItemGuid) ?? throw new ArgumentNullException($"The linked content item with GUID '{targetItemGuid}' referenced by a ContentItemCommonData with GUID '{commonDataInfo.ContentItemCommonDataGUID}' does not exist or could not be found.");
-                                    yield return new()
+                                    foreach (var targetItemGuid in value.Select(x => x.Identifier))
                                     {
-                                        ContentItemReferenceGroupGUID = groupGuid,
-                                        ContentItemReferenceSourceCommonDataID = commonDataInfo.ContentItemCommonDataID,
-                                        ContentItemReferenceTargetItemID = contentItemInfo.ContentItemID,
-                                    };
+                                        var contentItemInfo = ContentItemInfo.Provider.Get(targetItemGuid) ?? throw new ArgumentNullException($"The linked content item with GUID '{targetItemGuid}' referenced by a ContentItemCommonData with GUID '{commonDataInfo.ContentItemCommonDataGUID}' does not exist or could not be found.");
+                                        yield return new()
+                                        {
+                                            ContentItemReferenceGroupGUID = groupGuid,
+                                            ContentItemReferenceSourceCommonDataID = commonDataInfo.ContentItemCommonDataID,
+                                            ContentItemReferenceTargetItemID = contentItemInfo.ContentItemID,
+                                        };
+                                    }
                                 }
                             }
                         }

--- a/src/Kentico.Xperience.UMT/Services/ContentItemReferencePopulator.cs
+++ b/src/Kentico.Xperience.UMT/Services/ContentItemReferencePopulator.cs
@@ -89,10 +89,10 @@ namespace Kentico.Xperience.UMT.Services
                 {
                     if (contentItemReferenceFieldValue is string serializedValue)
                     {
-                        if (!string.IsNullOrWhiteSpace(serializedValue))
-                        {
-                            var unescapedSerializedValue = Regex.Unescape(serializedValue).Trim('\"');
+                        var unescapedSerializedValue = Regex.Unescape(serializedValue).Trim('\"');
 
+                        if (!string.IsNullOrEmpty(unescapedSerializedValue))
+                        {
                             if (field.DataType is SchemaHelper.WEBPAGES_DATA_TYPE_NAME)
                             {
                                 var value = JsonSerializer.Deserialize<IEnumerable<WebPageRelatedItem>?>(unescapedSerializedValue, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });


### PR DESCRIPTION
… contains an empty JSON string

# Motivation

The problem was identified during testing with the customer database.

## Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [x] Tests are passing
- [n/a] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

Already tested.
